### PR TITLE
Implement Procutil.system4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ addons:
 compiler:
   - gcc
   - clang
+env:
+  # - MRUBY_VERSION=1.2.0
+  - MRUBY_VERSION=master
 script:
   - rake test
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
+sudo: false
 language: c
+addons:
+  apt:
+    packages:
+      - rake
+      - bison
+      - git
+      - gperf
+
 compiler:
   - gcc
   - clang
-before_install:
-    - sudo apt-get -qq update
-install:
-    - sudo apt-get -qq install rake bison git gperf
-before_script:
-  - cd ../
-  - git clone https://github.com/mruby/mruby.git
-  - cd mruby
-  - cp -fp ../mruby-procutil/.travis_build_config.rb build_config.rb
 script:
-  - make all test
+  - rake test
+branches:
+  only:
+    - master

--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -2,5 +2,7 @@ MRuby::Build.new do |conf|
   toolchain :gcc
   conf.gembox 'default'
   conf.gem '../mruby-procutil'
+  conf.gem mgem: 'mruby-io'
+  conf.gem mgem: 'mruby-process'
   conf.enable_test
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,4 +1,7 @@
 MRuby::Gem::Specification.new('mruby-procutil') do |spec|
   spec.license = 'MIT'
   spec.authors = 'Uchio Kondo'
+
+  spec.add_test_dependency 'mruby-io'
+  spec.add_test_dependency 'mruby-process'
 end

--- a/mrblib/mrb_procutil.rb
+++ b/mrblib/mrb_procutil.rb
@@ -1,2 +1,24 @@
 module Procutil
+  def system4(cmd, newstdin=nil, newstdout=nil, newstderr=nil)
+    newstdin  ||= 0
+    newstdout ||= 1
+    newstderr ||= 2
+    pid, status = *__system4(cmd, to_fileno(newstdin), to_fileno(newstdout), to_fileno(newstderr))
+    if Object.const_defined?(:Process) && Process.const_defined?(:Status)
+      Process::Status.new(pid, status)
+    else
+      [pid, status]
+    end
+  end
+  module_function :system4
+
+  def to_fileno(fd_or_io)
+    if fd_or_io.is_a?(Integer)
+      fd_or_io
+    else
+      fd_or_io.fileno
+    end
+  end
+  module_function :to_fileno
+  private :to_fileno
 end

--- a/test/mrb_procutil.rb
+++ b/test/mrb_procutil.rb
@@ -7,3 +7,12 @@ assert("Procutil.sethostname") do
     Procutil.sethostname("foo.jp")
   end
 end
+
+assert("Procutil.system4") do
+  devnull = File.open("/dev/null", "w")
+
+  ret = Procutil.system4 'ls -l', nil, devnull, devnull
+  assert_true ret.is_a?(Process::Status)
+  assert_true ret.pid > 0
+  assert_equal 0, ret.exitstatus
+end


### PR DESCRIPTION
This may be just a `Kernel#system`, which replaces stdin/stdout/stderr as you like.

Exapmle:

``` ruby
r, w = IO.pipe
pid = fork do
  Procutil.system4 "ls -l", 0, w, w
  w.puts "\0"
end
while l = r.readline
  break if l.include?("\0")
  puts "[SYSTEM4]:\t\e[34m#{l.chomp}\e[0m"

end
Process.waitpid pid
puts "OK"
```

``` console
$ ./mruby/bin/mruby /tmp/system4.rb 
[SYSTEM4]:      合計 1216
[SYSTEM4]:      -rw-r--r-- 1 vagrant vagrant 122880  8月  4 08:39 GPATH
[SYSTEM4]:      -rw-r--r-- 1 vagrant vagrant 860160  8月  4 08:39 GRTAGS
[SYSTEM4]:      -rw-r--r-- 1 vagrant vagrant 237568  8月  4 08:39 GTAGS
[SYSTEM4]:      -rw-r--r-- 1 vagrant vagrant   1141  7月  8 16:27 LICENSE
[SYSTEM4]:      -rw-r--r-- 1 vagrant vagrant    416  7月  9 05:26 README.md
[SYSTEM4]:      -rw-r--r-- 1 vagrant vagrant    718  7月  9 05:47 Rakefile
[SYSTEM4]:      -rw-r--r-- 1 vagrant vagrant    718  7月  9 05:12 Rakefile~
[SYSTEM4]:      -rw-r--r-- 1 vagrant vagrant    198  8月  4 08:47 mrbgem.rake
[SYSTEM4]:      drwxr-xr-x 1 vagrant vagrant    102  8月  4 08:48 mrblib
[SYSTEM4]:      drwxr-xr-x 1 vagrant vagrant   1156  8月  4 08:52 mruby
[SYSTEM4]:      -rw-r--r-- 1 vagrant vagrant    194  7月  8 16:27 mruby-procutil.gem
[SYSTEM4]:      drwxr-xr-x 1 vagrant vagrant    136  8月  4 08:39 src
[SYSTEM4]:      drwxr-xr-x 1 vagrant vagrant    102  8月  4 08:52 test
OK
```
