### PR TITLE
Implement Procutil.fd_reopen3(new0, new1, new2)

### DIFF
--- a/examples/reexec.rb
+++ b/examples/reexec.rb
@@ -1,0 +1,8 @@
+log = File.open("/tmp/log.txt", "a+")
+Procutil.fd_reopen3(0, log.fileno, log.fileno)
+loop do
+  puts "Test"
+  $stderr.puts "[Error] Test"
+  sleep 1
+end
+


### PR DESCRIPTION
This enable the container daemons to emit logs to files.