### PR TITLE
Add strerror_r error handling

### DIFF
--- a/src/mrb_procutil.c
+++ b/src/mrb_procutil.c
@@ -43,8 +43,8 @@ static void mrb_procutil_sys_fail(mrb_state *mrb, int error_no, const char *fmt,
   va_end(args);
 
   if ((ret = strerror_r(error_no, buf, 1024)) == NULL) {
-    mrb_procutil_sys_fail(mrb, errno, "[BUG] strerror_r failed at %s:%s. Please report haconiwa-dev", __FILE__,
-                          __func__);
+    snprintf(err_msg, SYS_FAIL_MESSAGE_LENGTH, "[BUG] strerror_r failed. errno: %d", errno);
+    mrb_sys_fail(mrb, err_msg);
   }
 
   snprintf(err_msg, SYS_FAIL_MESSAGE_LENGTH, "sys failed. errno: %d message: %s mrbgem message: %s", error_no, ret,

--- a/src/mrb_procutil.c
+++ b/src/mrb_procutil.c
@@ -43,9 +43,8 @@ static void mrb_procutil_sys_fail(mrb_state *mrb, int error_no, const char *fmt,
   va_end(args);
 
   if ((ret = strerror_r(error_no, buf, 1024)) == NULL) {
-    snprintf(err_msg, SYS_FAIL_MESSAGE_LENGTH, "[BUG] strerror_r failed at %s:%s. Please report haconiwa-dev", __FILE__,
-             __func__);
-    mrb_sys_fail(mrb, err_msg);
+    mrb_procutil_sys_fail(mrb, errno, "[BUG] strerror_r failed at %s:%s. Please report haconiwa-dev", __FILE__,
+                          __func__);
   }
 
   snprintf(err_msg, SYS_FAIL_MESSAGE_LENGTH, "sys failed. errno: %d message: %s mrbgem message: %s", error_no, ret,


### PR DESCRIPTION
Hi!  @udzura 


I added more information when strerror was failed.

```
Feb  1 08:20:26 udzura haconiwa.haconiwa-tester-2458[1]: [BUG] strerror_r failed at 
/Users/udzura/.ghq/github.com/haconiwa/haconiwa/mruby/build/mrbgems/mruby-
procutil/src/mrb_procutil.c:mrb_procutil_sys_fail. Please report haconiwa-dev

Feb  1 08:20:26 udzura haconiwa.haconiwa-tester-2458[1]: An exception is occurred when 
spawning haconiwa:
```