### PR TITLE
mruby1.3.0とmasterへの対応

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ compiler:
   - clang
 env:
   # - MRUBY_VERSION=1.2.0
+  - MRUBY_VERSION=1.3.0
   - MRUBY_VERSION=master
 script:
   - rake format

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 MRUBY_CONFIG=File.expand_path(ENV["MRUBY_CONFIG"] || ".travis_build_config.rb")
-MRUBY_VERSION=ENV["MRUBY_VERSION"] || "1.2.0"
+MRUBY_VERSION=ENV["MRUBY_VERSION"] || "master"
 
 file :mruby do
   cmd =  "git clone --depth=1 git://github.com/mruby/mruby.git"

--- a/src/mrb_procutil.c
+++ b/src/mrb_procutil.c
@@ -140,7 +140,7 @@ static mrb_value mrb_procutil_mark_cloexec(mrb_state *mrb, mrb_value self)
 
 static mrb_value mrb_procutil___system4(mrb_state *mrb, mrb_value self)
 {
-  int stdin_fd, stdout_fd, stderr_fd;
+  mrb_int stdin_fd, stdout_fd, stderr_fd;
   int exit_status = -1, check_status;
   char *cmd;
   pid_t pid;

--- a/src/mrb_procutil.c
+++ b/src/mrb_procutil.c
@@ -55,7 +55,7 @@ static void mrb_procutil_sys_fail(mrb_state *mrb, int error_no, const char *fmt,
 static mrb_value mrb_procutil_sethostname(mrb_state *mrb, mrb_value self)
 {
   char *newhostname;
-  int len;
+  mrb_int len;
   mrb_get_args(mrb, "s", &newhostname, &len);
 
   if (sethostname(newhostname, len) < 0) {


### PR DESCRIPTION
- ```int len ```　=>```mrb_int len```   に変更
- Rakefile内のmrubyバージョンをmasterに変更
- travis.ymlのenvに1.3.0を追加